### PR TITLE
Update Conan recipes to CCI versions

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,6 +1,7 @@
 [requires]
-glm/0.9.9.1@g-truc/stable
-gtest/1.8.1@bincrafters/stable
+glm/0.9.9.5
+gtest/1.8.1
+benchmark/1.5.0
 crossguid/06-03-19@inexorgame/testing
 #jsonformoderncpp/3.5.0@vthiery/stable
 restbed/6eb385fa9051203f28bf96cc1844bbb5a9a6481f@inexorgame/stable
@@ -17,7 +18,6 @@ magnum/2019.01@inexorgame/testing
 openal/1.19.0@bincrafters/stable
 magnum_plugins/2019.01@inexorgame/testing
 freetype/2.9.1@bincrafters/stable
-google-benchmark/1.4.1@mpusz/stable
 
 [generators]
 cmake


### PR DESCRIPTION
Update glm, gtest and benchmark to their new [Conan Center Index](https://github.com/conan-io/conan-center-index/) versions

You should consider adding gtest and benchmark only as build_requires, when they are indeed only build requirements